### PR TITLE
treat all files as text files with lf line-endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
+* text=auto eol=lf
+
 tsconfig.*.json linguist-language=jsonc


### PR DESCRIPTION
This should fix the linting issues on windows - [though a re-clone may need to be preformed](https://prettier.io/docs/en/options.html#:~:text=You%20may%20need%20to%20ask%20Windows%20users%20to%20re-clone%20your%20repo%20after%20this%20change%20to%20ensure%20git%20has%20not%20converted%20LF%20to%20CRLF%20on%20checkout.)