### PR TITLE
fix: typing of reduce operation

### DIFF
--- a/src/ops/reduce.ts
+++ b/src/ops/reduce.ts
@@ -8,15 +8,15 @@ import {createOperation} from '../utils';
  *
  * @category Sync+Async
  */
-export function reduce<T>(
+export function reduce<T, R = T>(
     cb: (
-        previousValue: T,
+        previousValue: R,
         currentValue: T,
         index: number,
         state: IterationState
-    ) => T,
-    initialValue?: T
-): Operation<T, T>;
+    ) => R,
+    initialValue?: R
+): Operation<T, R>;
 
 export function reduce(...args: unknown[]) {
     return createOperation(reduceSync, reduceAsync, args);

--- a/test/reduce.spec.ts
+++ b/test/reduce.spec.ts
@@ -18,6 +18,20 @@ describe('sync reduce', () => {
         );
         expect(output.first).to.eql(45);
     });
+    it('must be able to convert the type', () => {
+        const input = [
+            [1, 2],
+            [3, 4],
+            [5, 6],
+            [7, 8],
+            [9, 0],
+        ];
+        const output = pipe(
+            input,
+            reduce((c, i) => c + i[0] * i[1], 0)
+        );
+        expect(output.first).to.eql(100);
+    });
     it('must not generate more than one value', () => {
         const input = [1, 2];
         const output = pipe(


### PR DESCRIPTION
The out type doesn't have to be the same as the in type.