### PR TITLE
feat: filter operation can now narrow types when given a type guard

### DIFF
--- a/src/ops/filter.ts
+++ b/src/ops/filter.ts
@@ -2,6 +2,31 @@ import {$A, $S, IterationState, Operation} from '../types';
 import {createOperation, isPromiseLike} from '../utils';
 
 /**
+ * Standard `Array.filter` logic for the iterable, extended with iteration state.
+ *
+ * In the example below, we are able to use a type guard to filter out all the nullable values.
+ *
+ * ```ts
+ * import {pipe, filter} from 'iter-ops';
+ *
+ * const i = pipe(
+ *     [1, null, "foo"],
+ *     filter((value): value is NonNullable<typeof value> => value != null)
+ * );
+ * ```
+ *
+ * Note: The asynchronous version of this function cannot make use of type guards.\
+ * Give a :+1: to the [Asynchronous Type Guards issue](https://github.com/microsoft/TypeScript/issues/37681)
+ * if you want support for this.
+ *
+ * @see [Array.filter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter)
+ * @category Sync
+ */
+export function filter<T, S extends T = T>(
+    cb: (value: T, index: number, state: IterationState) => value is S
+): Operation<T, S>;
+
+/**
  * Standard `Array.filter` logic for the iterable, extended with iteration state + async.
  *
  * In the example below, we take advantage of the {@link IterationState}, to detect and remove repeated

--- a/test/filter.spec.ts
+++ b/test/filter.spec.ts
@@ -10,6 +10,18 @@ describe('sync filter', () => {
         );
         expect([...output]).to.eql([1, 2, 0]);
     });
+    it('must use type gaurds info to narrow type', () => {
+        const input = [1, 2, null, 4, undefined, 0];
+
+        const output: Iterable<number> = pipe(
+            input,
+            filter(
+                (value): value is NonNullable<typeof value> =>
+                    value !== null && value !== undefined
+            )
+        );
+        expect([...output]).to.eql([1, 2, 4, 0]);
+    });
     it('must reuse the state object', () => {
         const input = 'hello!';
         const arr: number[] = [];


### PR DESCRIPTION
This only works with (and can only work with) the sync version.

See [asynchronous type guards](https://github.com/microsoft/TypeScript/issues/37681) for details on how an async version could work in future.