### PR TITLE
fix: Fix the definition of Operation

### DIFF
--- a/src/ops/spread.ts
+++ b/src/ops/spread.ts
@@ -23,8 +23,8 @@ import {createOperation} from '../utils';
  */
 export function spread<T>(): Operation<Iterable<T> | AsyncIterable<T>, T>;
 
-export function spread(...args: unknown[]) {
-    return createOperation(spreadSync, spreadAsync, args);
+export function spread<T>(...args: unknown[]) {
+    return createOperation<Iterable<T>, T>(spreadSync, spreadAsync, args);
 }
 
 function spreadSync<T>(iterable: Iterable<Iterable<T>>): Iterable<T> {

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -7,7 +7,7 @@ import {
     Operation,
 } from './types';
 import {catchError} from './ops/catch-error';
-import {optimizeIterable} from './utils';
+import {isAsyncIterable, isIterable, optimizeIterable} from './utils';
 
 /** @hidden */
 export function pipe<T>(i: Iterable<T>): IterableExt<T>;
@@ -216,15 +216,15 @@ export function pipe<T, A, B, C, D, E, F, G, H, I, J>(
     p9: Operation<I, J>
 ): AsyncIterableExt<J>;
 
-export function pipe(
-    i: any,
-    ...p: any[]
-): IterableExt<any> | AsyncIterableExt<any> {
-    if (i[$S]) {
+export function pipe<T>(
+    i: AnyIterable<T>,
+    ...p: Operation<T, T>[]
+): IterableExt<T> | AsyncIterableExt<T> {
+    if (isIterable(i)) {
         // create synchronous pipeline:
         return extendIterable(p.reduce((c, a) => a(c), optimizeIterable(i)));
     }
-    if (i[$A]) {
+    if (isAsyncIterable(i)) {
         // create asynchronous pipeline:
         return extendAsyncIterable(p.reduce((c, a) => a(c), i));
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,7 +109,8 @@ export type AnyIterableIterator<T> = AnyIterable<T> | AnyIterator<T>;
  * Pipe-through type (return type for all operators)
  */
 export interface Operation<T, R> {
-    (i: AnyIterable<T>): Operation<T, R>;
+    (i: Iterable<T>): Iterable<R>;
+    (i: AsyncIterable<T>): AsyncIterable<R>;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import {$A, $S, Operation} from './types';
+import {$A, $S, type Operation, type AnyIterable} from './types';
 
 /**
  * Wraps operator signature.
@@ -7,7 +7,7 @@ export function createOperation<T, R>(
     syncFunc: (i: Iterable<T>, ...args: any[]) => Iterable<R>,
     asyncFunc: (i: AsyncIterable<T>, ...args: any[]) => AsyncIterable<R>,
     args?: Iterable<unknown>
-): Operation<T, T> {
+): Operation<T, R> {
     return (i: any) => {
         const func: any = i[$S] ? syncFunc : asyncFunc;
         return func.apply(null, [i, ...(args || [])]);
@@ -114,4 +114,12 @@ export function isIndexed(input: any): boolean {
  */
 export function isPromiseLike(a: any): boolean {
     return a && typeof a.then === 'function';
+}
+
+export function isIterable<T>(i: AnyIterable<T>): i is Iterable<T> {
+    return !!(<Iterable<T>>i)[$S];
+}
+
+export function isAsyncIterable<T>(i: AnyIterable<T>): i is AsyncIterable<T> {
+    return !!(<AsyncIterable<T>>i)[$A];
 }


### PR DESCRIPTION
An operation is a function that takes an Iterator and returns an Iterator.

But this was begin hidden by the `any`s in the `pipe` function.


**tldr;**
Many years ago before async iterators existed, I wrote [GenSequence: Small library to simplify working with Generators and Iterators in JavaScript / Typescript](https://github.com/Jason3S/GenSequence). It is a bit over done. Too much Iterator conversion going on to support chaining. For a while I wanted to simplify and drop the chaining by moving towards using a `pipe` approach while reducing overhead.

I recently saw your implementation and considered deprecating GenSequence. But I noticed that this repo uses a lot of `any`s, which hide possible problems.

For example, Operation's definition didn't match how it was being used in `pipe`, which is the reason for this PR.

If you would like some help removing the `any`s, I can help. I do suggest making both `pipeSync` and `pipeAsync` functions. This will simplify things. 

 