### PR TITLE
Adjust file structure of types

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -131,9 +131,3 @@ export type Any<T> = AnySync<T> | AsyncIterator<T> | AsyncIterable<T>;
  * @see {@link https://github.com/vitaly-t/iter-ops/wiki/Iteration-State Iteration State WiKi}
  */
 export type IterationState = {[name: string]: any};
-
-/**
- * These are for code abbreviation + smaller bundles:
- */
-export const $S: typeof Symbol.iterator = Symbol.iterator;
-export const $A: typeof Symbol.asyncIterator = Symbol.asyncIterator;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,18 @@
+export {
+    IErrorContext,
+    IterableExt,
+    AsyncIterableExt,
+    AnyIterable,
+    AnyIterator,
+    AnyIterableIterator,
+    Operation,
+    AnySync,
+    Any,
+    IterationState,
+} from './common';
+
+/**
+ * These are for code abbreviation + smaller bundles:
+ */
+export const $S: typeof Symbol.iterator = Symbol.iterator;
+export const $A: typeof Symbol.asyncIterator = Symbol.asyncIterator;


### PR DESCRIPTION
The point of this change is simply to minimize diffs of future PRs by pre-moving the type file to a types folder.
Other PRs will want to introduce more types and will want to create new files for those types.
e.g. #96 adds a typeguards.ts file.