### PR TITLE
docs: improve typedoc generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "check-format": "cross-env prettier --list-different \"./**/*.{json,yml,md,ts}\"",
     "check-spelling": "cross-env cspell --config=.cspell.json \"**/*.{md,ts}\"",
     "clean": "cross-env rimraf dist",
-    "doc": "cross-env typedoc --tsconfig tsconfig.build.json --readme none",
+    "doc": "cross-env typedoc --readme none",
     "format": "cross-env prettier --write \"./**/*.{json,yml,md,ts}\"",
     "lint": "cross-env eslint .",
     "test": "cross-env npm run test:js && cross-env npm run test:types",

--- a/src/ops/count.ts
+++ b/src/ops/count.ts
@@ -72,7 +72,7 @@ export function count<T>(
  *
  * Note that the predicate can only return a `Promise` inside an asynchronous pipeline.
  *
- * @category Async
+ * @category Sync+Async
  */
 export function count<T>(
     cb: (value: T, index: number, state: IterationState) => Promise<boolean>

--- a/src/ops/every.ts
+++ b/src/ops/every.ts
@@ -52,7 +52,7 @@ export function every<T>(
  * @see
  *  - [Array.every](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every)
  *  - {@link some}
- * @category Async
+ * @category Sync+Async
  */
 export function every<T>(
     cb: (value: T, index: number, state: IterationState) => Promise<boolean>

--- a/src/ops/filter.ts
+++ b/src/ops/filter.ts
@@ -29,7 +29,7 @@ import {createOperation} from '../utils';
  *
  * @see
  *  - [Array.filter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter)
- * @category Sync
+ * @category Sync+Async
  */
 export function filter<T, S extends T = T>(
     cb: (value: T, index: number, state: IterationState) => value is S
@@ -91,7 +91,7 @@ export function filter<T>(
  *
  * @see
  *  - [Array.filter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter)
- * @category Async
+ * @category Sync+Async
  */
 export function filter<T>(
     cb: (value: T, index: number, state: IterationState) => Promise<boolean>

--- a/src/ops/first.ts
+++ b/src/ops/first.ts
@@ -80,7 +80,7 @@ export function first<T>(
  *  - {@link last}
  *  - {@link take}
  *  - {@link takeLast}
- * @category Async
+ * @category Sync+Async
  */
 export function first<T>(
     cb: (value: T, index: number) => Promise<boolean>

--- a/src/ops/last.ts
+++ b/src/ops/last.ts
@@ -74,7 +74,7 @@ export function last<T>(
  * @see
  *  - {@link takeLast}
  *  - {@link first}
- * @category Async
+ * @category Sync+Async
  */
 export function last<T>(
     cb: (value: T, index: number) => Promise<boolean>

--- a/src/ops/repeat.ts
+++ b/src/ops/repeat.ts
@@ -74,7 +74,7 @@ export function repeat<T>(
  *
  * @see
  *  - {@link retry}
- * @category Async
+ * @category Sync+Async
  */
 export function repeat<T>(
     cb: (

--- a/src/ops/some.ts
+++ b/src/ops/some.ts
@@ -52,7 +52,7 @@ export function some<T>(
  * @see
  *  - [Array.some](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some)
  *  - {@link every}
- * @category Async
+ * @category Sync+Async
  */
 export function some<T>(
     cb: (value: T, index: number, state: IterationState) => Promise<boolean>

--- a/src/ops/split.ts
+++ b/src/ops/split.ts
@@ -136,7 +136,7 @@ export function split<T>(
  * @see
  *  - {@link https://github.com/vitaly-t/iter-ops/wiki/Split Split WiKi}
  *  - {@link page}
- * @category Async
+ * @category Sync+Async
  */
 export function split<T>(
     cb: (

--- a/src/ops/start.ts
+++ b/src/ops/start.ts
@@ -42,7 +42,7 @@ export function start<T>(
  *
  * @see
  *  - {@link stop}
- * @category Async
+ * @category Sync+Async
  */
 export function start<T>(
     cb: (value: T, index: number, state: IterationState) => Promise<boolean>

--- a/src/ops/stop.ts
+++ b/src/ops/stop.ts
@@ -38,7 +38,7 @@ export function stop<T>(
  *
  * Note that the predicate can only return a `Promise` inside an asynchronous pipeline.
  *
- * @category Async
+ * @category Sync+Async
  */
 export function stop<T>(
     cb: (value: T, index: number, state: IterationState) => Promise<boolean>

--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -12,7 +12,6 @@ import {catchError} from './ops/catch-error';
 import {optimizeIterable} from './utils';
 import {isAsyncIterable, isSyncIterable} from './typeguards';
 
-/** @hidden */
 interface PipeSync {
     <T>(i: Iterable<T>): IterableExt<T>;
 
@@ -114,7 +113,6 @@ interface PipeSync {
     ): IterableExt<unknown>;
 }
 
-/** @hidden */
 interface PipeAsync {
     <T>(i: UnknownIterable<T>): AsyncIterableExt<T>;
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -5,7 +5,6 @@
   "out": "../iter-ops-docs",
   "excludeExternals": true,
   "excludePrivate": true,
-  "excludeNotDocumented": true,
   "cleanOutputDir": false,
   "entryPoints": ["src/index.ts"],
   "entryPointStrategy": "resolve",

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://typedoc.org/schema.json",
+  "tsconfig": "./tsconfig.build.json",
   "name": "ITER-OPS v2.0.0-beta.3",
   "out": "../iter-ops-docs",
   "excludeExternals": true,


### PR DESCRIPTION
This PR will tidy up the categories in the typedocs.

I agree that ideally, we don't want copy and paste the documentation for each overload, but I don't think this can be avoided if want to support intellisense.