### PR TITLE
fix: typings of flatMap operator

### DIFF
--- a/src/ops/flat-map.ts
+++ b/src/ops/flat-map.ts
@@ -13,12 +13,8 @@ import {isPromiseLike} from '../typeguards';
  * @category Sync+Async
  */
 export function flatMap<T, R>(
-    cb: (
-        value: T extends UnknownIterable<infer E> ? E : T,
-        index: number,
-        state: IterationState
-    ) => R
-): Operation<T, R>;
+    cb: (value: T, index: number, state: IterationState) => R
+): Operation<T, R extends UnknownIterable<infer E> ? E : R>;
 
 export function flatMap(...args: unknown[]) {
     return createOperation(flatMapSync as any, flatMapAsync as any, args);

--- a/test/ops/flat-map/types/async.test-d.ts
+++ b/test/ops/flat-map/types/async.test-d.ts
@@ -11,26 +11,53 @@ declare const iterable3: AsyncIterable<
 const test1 = pipeAsync(
     iterable1,
     flatMap((value) => {
-        expectType<number>(value);
+        expectType<AsyncIterable<number>>(value);
         return 123;
     })
 );
 expectType<AsyncIterableExt<number>>(test1);
 
 const test2 = pipeAsync(
-    iterable2,
+    iterable1,
     flatMap((value) => {
-        expectType<number>(value);
-        return 123;
+        expectType<AsyncIterable<number>>(value);
+        return [1, 2, 3];
     })
 );
 expectType<AsyncIterableExt<number>>(test2);
 
 const test3 = pipeAsync(
+    iterable2,
+    flatMap((value) => {
+        expectType<Iterable<number>>(value);
+        return 123;
+    })
+);
+expectType<AsyncIterableExt<number>>(test3);
+
+const test4 = pipeAsync(
+    iterable2,
+    flatMap((value) => {
+        expectType<Iterable<number>>(value);
+        return [1, 2, 3];
+    })
+);
+expectType<AsyncIterableExt<number>>(test4);
+
+const test5 = pipeAsync(
     iterable3,
     flatMap((value, index) => {
-        expectType<number | string | boolean>(value);
+        expectType<AsyncIterable<number> | Iterable<string> | boolean>(value);
         return index ? 123 : 'bla';
     })
 );
-expectAssignable<AsyncIterableExt<number | string>>(test3);
+expectAssignable<AsyncIterableExt<number | string>>(test5);
+
+const test6 = pipeAsync(
+    iterable3,
+    flatMap((value) => {
+        expectType<AsyncIterable<number> | Iterable<string> | boolean>(value);
+        return [123, 'bla'];
+    })
+);
+expectType<AsyncIterableExt<number | string>>(test6);

--- a/test/ops/flat-map/types/sync.test-d.ts
+++ b/test/ops/flat-map/types/sync.test-d.ts
@@ -3,12 +3,32 @@ import {expectType} from 'tsd';
 import {flatMap, IterableExt, pipeSync} from '../../../../src';
 
 declare const iterableNumber: Iterable<Iterable<number>>;
+declare const iterableEntries: IterableIterator<[string, number]>;
 
 const test1 = pipeSync(
     iterableNumber,
     flatMap((value) => {
-        expectType<number>(value);
+        expectType<Iterable<number>>(value);
         return 123;
     })
 );
 expectType<IterableExt<number>>(test1);
+
+const test2 = pipeSync(
+    iterableNumber,
+    flatMap((value) => {
+        expectType<Iterable<number>>(value);
+        return [1, 2, 3];
+    })
+);
+expectType<IterableExt<number>>(test2);
+
+const test3 = pipeSync(
+    iterableEntries,
+    flatMap(([key, value]) => {
+        expectType<string>(key);
+        expectType<number>(value);
+        return [1, 2, 3];
+    })
+);
+expectType<IterableExt<number>>(test3);


### PR DESCRIPTION
I got the typings wrong before. This should fix them.