### PR TITLE
fix: throw when the sync pipeline receives an async iterable

### DIFF
--- a/src/pipe.ts
+++ b/src/pipe.ts
@@ -266,15 +266,20 @@ export const pipe = ((
  *  - {@link pipeAsync}
  *  - {@link toIterable}
  *  - {@link toAsync}
+ * @throws If the iterable is asynchronous.
  * @category Core
  */
 export const pipeSync = ((
     i: UnknownIterable<unknown>,
     ...p: readonly Operation<unknown, unknown>[]
-) =>
-    extendIterable(
-        p.reduce((c, a: any) => a(c), optimizeIterable(i))
-    )) as PipeSync;
+) => {
+    if (isAsyncIterable(i)) {
+        throw new TypeError(
+            'Cannot run the sync pipeline from an AsyncIterable'
+        );
+    }
+    return extendIterable(p.reduce((c, a: any) => a(c), optimizeIterable(i)));
+}) as PipeSync;
 
 /**
  * Pipes an `UnknownIterable` or `AsyncIterable` through the list of asynchronous operators, and returns {@link AsyncIterableExt}.

--- a/test/pipe/sync.ts
+++ b/test/pipe/sync.ts
@@ -1,4 +1,4 @@
-import {expect} from '../header';
+import {expect, _async} from '../header';
 import {pipeSync} from '../../src';
 
 export default () => {
@@ -30,9 +30,14 @@ export default () => {
         });
     });
     describe('with invalid inputs', () => {
-        it('must throw an error', () => {
+        it('must throw an error when given a non-iterable', () => {
             expect(() => {
                 pipeSync(123 as any);
+            }).to.throw();
+        });
+        it('must throw an error when given an async iterable', () => {
+            expect(() => {
+                pipeSync(_async([1, 2, 3]) as any);
             }).to.throw();
         });
     });


### PR DESCRIPTION
fix #177