### PR TITLE
feat: add support for converting an array-like to an iterable

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -191,10 +191,21 @@ export function toIterable<T>(i: unknown) {
         if (isPromiseLike<typeof i, T>(i)) {
             return toSingleAsyncIterable(i);
         }
-    }
 
-    if (isArrayLike(i)) {
-        return Array.from(i);
+        if (isArrayLike(i)) {
+            return {
+                [$S](): Iterator<T> {
+                    let k = 0;
+                    return {
+                        next() {
+                            return k < i.length
+                                ? {value: i[k++] as T, done: false}
+                                : {value: undefined, done: true};
+                        },
+                    };
+                },
+            };
+        }
     }
 
     // A sync value.

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -6,6 +6,7 @@ import {
     isObject,
     isPromiseLike,
     isIndexed,
+    isArrayLike,
 } from './typeguards';
 import {$A, $S, UnknownIterable} from './types';
 import {indexedAsyncIterable} from './utils';
@@ -88,6 +89,17 @@ export function toIterable<T>(i: Iterator<T>): Iterable<T>;
  * @category Core
  */
 export function toIterable<T>(i: AsyncIterator<T>): AsyncIterable<T>;
+
+/**
+ * Converts an array-like object into a synchronous `Iterable`, so it can be used as a pipeline source/input.
+ *
+ * @see
+ *  - {@link https://github.com/vitaly-t/iter-ops/wiki/Iterators Iterators}
+ *  - {@link toAsync}
+ *  - {@link pipe}
+ * @category Core
+ */
+export function toIterable<T>(i: ArrayLike<T>): Iterable<T>;
 
 /**
  * Synchronous type inference helper.
@@ -179,6 +191,10 @@ export function toIterable<T>(i: unknown) {
         if (isPromiseLike<typeof i, T>(i)) {
             return toSingleAsyncIterable(i);
         }
+    }
+
+    if (isArrayLike(i)) {
+        return Array.from(i);
     }
 
     // A sync value.

--- a/src/typeguards.ts
+++ b/src/typeguards.ts
@@ -56,6 +56,17 @@ export function isPromiseLike<T, CastGeneric = unknown>(
 }
 
 /**
+ * Determines if the value is array-like.
+ */
+export function isArrayLike<T, CastGeneric = unknown>(
+    value: T
+): value is T & ArrayLike<CastGeneric> {
+    return (
+        hasOfType(value, 'length', 'number') && Number.isInteger(value.length)
+    );
+}
+
+/**
  * Determines if the value is an iterable.
  */
 export function isSyncIterable<T, CastGeneric = unknown>(

--- a/test/helpers.spec.ts
+++ b/test/helpers.spec.ts
@@ -39,6 +39,16 @@ describe('toIterable', () => {
         const i2 = toIterable(null);
         expect([...i2]).to.eql([null]);
     });
+    it('must convert an array-like object', () => {
+        const input = {
+            length: 3,
+            0: 2,
+            1: 3,
+            2: 4,
+        };
+        const i = toIterable(input);
+        expect([...i]).to.eql([2, 3, 4]);
+    });
     it('must convert a resolved Promise', async () => {
         const i = toIterable(Promise.resolve(123));
         expect(await _asyncValues(i)).to.eql([123]);


### PR DESCRIPTION
I've set this up to work for the sync case.
The async case will be a little more complicated.

However, I'm not sure if this is worth pursuing as it can lead to false matches users will not be expecting. The only way we can test if something is array-like is by seeing if it has a `length` property and that it is an integer. However, it is quite plausible for an object to meet that criteria without being array-like. We'd need to add an escape hatch for this case, which would be more work than it's worth imo.