### PR TITLE
fix(take): do not consume one extra element when finishing

### DIFF
--- a/src/ops/take.ts
+++ b/src/ops/take.ts
@@ -36,9 +36,10 @@ function takeSync<T>(iterable: Iterable<T>, count: number): Iterable<T> {
                 finished: boolean;
             return {
                 next(): IteratorResult<T> {
+                    finished = finished || index++ >= count;
                     if (!finished) {
                         const a = i.next();
-                        finished = a.done || index++ >= count;
+                        finished = a.done;
                         if (!finished) {
                             return a;
                         }
@@ -61,11 +62,12 @@ function takeAsync<T>(
                 finished: boolean;
             return {
                 next(): Promise<IteratorResult<T>> {
+                    finished = finished || index++ >= count
                     if (finished) {
                         return Promise.resolve({value: undefined, done: true});
                     }
                     return i.next().then((a) => {
-                        finished = a.done || index++ >= count;
+                        finished = a.done;
                         return finished ? {value: undefined, done: true} : a;
                     });
                 }

--- a/src/ops/take.ts
+++ b/src/ops/take.ts
@@ -39,7 +39,7 @@ function takeSync<T>(iterable: Iterable<T>, count: number): Iterable<T> {
                     finished = finished || index++ >= count;
                     if (!finished) {
                         const a = i.next();
-                        finished = a.done;
+                        finished = !!a.done;
                         if (!finished) {
                             return a;
                         }
@@ -62,12 +62,12 @@ function takeAsync<T>(
                 finished: boolean;
             return {
                 next(): Promise<IteratorResult<T>> {
-                    finished = finished || index++ >= count
+                    finished = finished || index++ >= count;
                     if (finished) {
                         return Promise.resolve({value: undefined, done: true});
                     }
                     return i.next().then((a) => {
-                        finished = a.done;
+                        finished = !!a.done;
                         return finished ? {value: undefined, done: true} : a;
                     });
                 }


### PR DESCRIPTION
Currently `take` consumes one extra element before finishing up. The check `index >= count` should be done before consuming next element.

